### PR TITLE
fix: manufacturer and brand filtering

### DIFF
--- a/packages/api-client/src/api/getProducts/index.ts
+++ b/packages/api-client/src/api/getProducts/index.ts
@@ -14,8 +14,13 @@ export default async function getProducts({ client, config }: ApiContext, params
       include = 'default_variant,variants.option_values,option_types,taxons,images';
     }
 
+    const unique = Array.from(new Set(productPropertyFilters.map(filter => filter.productPropertyName)).values())
+    let properties = {};
+    for (var uniqueProperty of unique){
+       properties[uniqueProperty] = (productPropertyFilters.filter(property => property.productPropertyName === uniqueProperty).map(property => property.productPropertyValue)).join(',')
+      }
+
     const optionValueIds = optionTypeFilters?.map(filter => filter.optionValueId);
-    const properties = productPropertyFilters?.reduce((result, filter) => ({ ...result, [filter.productPropertyName]: filter.productPropertyValue }), {});
 
     const result = await client.products.list(
       undefined,

--- a/packages/api-client/src/api/getProducts/index.ts
+++ b/packages/api-client/src/api/getProducts/index.ts
@@ -14,11 +14,13 @@ export default async function getProducts({ client, config }: ApiContext, params
       include = 'default_variant,variants.option_values,option_types,taxons,images';
     }
 
-    const unique = Array.from(new Set(productPropertyFilters.map(filter => filter.productPropertyName)).values())
-    let properties = {};
-    for (var uniqueProperty of unique){
-       properties[uniqueProperty] = (productPropertyFilters.filter(property => property.productPropertyName === uniqueProperty).map(property => property.productPropertyValue)).join(',')
-      }
+    const uniqueProductPropertyNames = Array.from(new Set(productPropertyFilters.map(filter => filter.productPropertyName)).values());
+    const properties = {};
+    for (const uniqueProperty of uniqueProductPropertyNames) {
+      const filteredProductPropertyNames = productPropertyFilters.filter(property => property.productPropertyName === uniqueProperty);
+      const mappedProductPropertyNames = filteredProductPropertyNames.map(property => property.productPropertyValue);
+      properties[uniqueProperty] = mappedProductPropertyNames.join(',');
+    }
 
     const optionValueIds = optionTypeFilters?.map(filter => filter.optionValueId);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Changed  the way of reading the params(brand, manufacturer) that an user provided to include all chosen options
## Description
<!--- Describe your changes in detail -->
Changed mapping of the params chosen by user to be further send to backend. Instead of getting only one parameter per category now all the ticked brands and manufacturers are filtered and send deeper. The initial procedure has not changed much, firstly chosen product properties are distinctly mapped to categories visible on the "filters" page, then all the ticked    brands/manufacturers are filtered and assigned to a set, that is sent to the spree backend

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Now filtering by brand/manufacturer is working as it was supposed to.
Before:
Only the last chosen parameter was mapped and used in the backend (for example all the brands were ticked which should result in all the products being show but instead of it only a few were)

Now:
All the chosen parameters are being filtered ( based on above example if someone ticks all the brands, all the products associated with those brands will be shown)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually, by checking search results with gathered data(what products are which brand/manufacturer)
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
