### PR TITLE
fix: refactored price filtering and changed it to be a slider instead of checkboxes

### DIFF
--- a/packages/theme/components/FiltersSidebar.vue
+++ b/packages/theme/components/FiltersSidebar.vue
@@ -67,7 +67,7 @@
                 :value="setStartingRange()"
                 :disabled="false"
                 :config="priceRangeConfig"
-                class="filters__item"
+                class="filters__smartphone-slider"
                 @change="(value) => onPriceChanged(facet,value)"
               />
             </div>
@@ -145,7 +145,7 @@ export default {
       range = urlPriceRange.split(',');
       selectedPrice.value = ([range[0], range[1]].map(String)).join(',');
     }
-    selectedPrice.value = ([range[0], range[1]].map(String)).join(',')
+    selectedPrice.value = ([range[0], range[1]].map(String)).join(',');
 
     const facets = computed(() => facetGetters.getGrouped(result.value, ['color', 'size']));
     const selectedFilters = ref({});
@@ -300,6 +300,7 @@ export default {
     --checkbox-padding: 0 var(--spacer-sm) 0 var(--spacer-xl);
     padding: var(--spacer-sm) 0;
     border-bottom: 1px solid var(--c-light);
+
     &:last-child {
       border-bottom: 0;
     }
@@ -309,6 +310,15 @@ export default {
       border: 0;
       padding: 0;
     }
+  }
+  &__smartphone-slider{
+    --radio-container-padding: 0 var(--spacer-sm)  var(--spacer-xl);
+    --radio-background: transparent;
+    --filter-label-color: var(--c-secondary-variant);
+    --filter-count-color: var(--c-secondary-variant);
+    border-bottom: 1px solid var(--c-light);
+    border-right: 70px solid var(--c-white);
+
   }
   &__accordion-item {
     --accordion-item-content-padding: 0;

--- a/packages/theme/components/FiltersSidebar.vue
+++ b/packages/theme/components/FiltersSidebar.vue
@@ -179,10 +179,10 @@ export default {
       tooltips: true,
       keyboardSupport: true,
       format: {to: function(value) {
-        return new Intl.NumberFormat('de-DE', {style: 'currency', currency: 'USD'}).format(value);
+        return new Intl.NumberFormat('de-DE', {style: 'currency', currency: 'USD'}).format(value).replace(/[$]/g, '');
       },
       from: function(value) {
-        return new Intl.NumberFormat('de-DE', {style: 'currency', currency: 'USD'}).formatToParts(value)[0].value;
+        return value;
       }},
       ariaFormat: {to: function (value) {
         return value;
@@ -190,8 +190,8 @@ export default {
     });
 
     const onPriceChanged = (facet, value) => {
-      const minChosenPrice = value[0].slice(0, -5);
-      const maxChosenPrice = value[1].slice(0, -5);
+      const minChosenPrice = value[0].slice(0, -4);
+      const maxChosenPrice = value[1].slice(0, -4);
       selectedPrice.value = ([minChosenPrice, maxChosenPrice].map(String)).join(',');
     };
 

--- a/packages/theme/components/FiltersSidebar.vue
+++ b/packages/theme/components/FiltersSidebar.vue
@@ -192,8 +192,6 @@ export default {
     const onPriceChanged = (facet, value) => {
       const minChosenPrice = value[0].slice(0, -5);
       const maxChosenPrice = value[1].slice(0, -5);
-      console.log(minChosenPrice);
-      console.log(maxChosenPrice);
       selectedPrice.value = ([minChosenPrice, maxChosenPrice].map(String)).join(',');
     };
 

--- a/packages/theme/composables/useUiHelpers/index.ts
+++ b/packages/theme/composables/useUiHelpers/index.ts
@@ -29,7 +29,6 @@ const getOptionTypeFiltersFromURL = (): SearchParamsOptionTypeFilter[] => {
 const getProductPropertyFiltersFromURL = (): SearchParamsProductPropertyFilter[] => {
   const instance = getInstance();
   const { query } = instance.$route;
-
   return Object
     .entries(query)
     .filter(([key]) => key.startsWith('p.'))
@@ -75,6 +74,7 @@ const useUiHelpers = () => {
     const queryWithoutFilters = Object.fromEntries(
       Object.entries(query).filter(([key]) => !key.startsWith('o.') && !key.startsWith('p.') && key !== 'price')
     );
+
     instance.$router.push({ query: { ...queryWithoutFilters, ...filters }});
   };
 
@@ -88,6 +88,10 @@ const useUiHelpers = () => {
 
   const isFacetColor = (facet: AgnosticGroupedFacet): boolean => facet.label === 'Color';
 
+  const isFacetPrice = (facet: AgnosticGroupedFacet): boolean => facet.label === 'Price';
+
+  const getSearchPriceFromUrl = () => getFacetsFromURL().priceFilter;
+
   const isFacetCheckbox = (facet: AgnosticGroupedFacet): boolean => !isFacetColor(facet);
 
   const getSearchTermFromUrl = () => getFacetsFromURL().term;
@@ -100,8 +104,10 @@ const useUiHelpers = () => {
     changeItemsPerPage,
     setTermForUrl,
     isFacetColor,
+    isFacetPrice,
     isFacetCheckbox,
-    getSearchTermFromUrl
+    getSearchTermFromUrl,
+    getSearchPriceFromUrl
   };
 };
 


### PR DESCRIPTION
Fixed price filtering and changed it to use a slider instead of checkboxes
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Refactored frontend part of price filtering which was in a "filters" sidebar, introduced SfRange component that is part of storefront-ui package and integrated it into sidebar

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Before user could  choose multiple intervals of price and if the intervals did not overlap we needed to do multiple queries to get the proper result. Also the checkboxes were bugged so only the last chosen interval was send deeper into code and was used in spree search query. Introduction of slider solves the first mentioned problem and also fixes the way that price is being filtered by spree core. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually by checking multiple usage scenarios
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
